### PR TITLE
Disable static discovery in API builder

### DIFF
--- a/quickstart.py
+++ b/quickstart.py
@@ -27,7 +27,7 @@ if not creds or not creds.valid:
         creds = flow.run_local_server(port = 0)
     with open("token.pickle", "wb") as tokenFile:
         pickle.dump(creds, tokenFile)
-service = build('photoslibrary', 'v1', credentials = creds)
+service = build('photoslibrary', 'v1', credentials = creds, static_discovery = False)
 
 # Call the Photo v1 API
 results = service.albums().list(


### PR DESCRIPTION
I imagine due to behind-the-scenes shenanigans at Google, this flag now needs to be passed to the discovery builder in order to access the Photos API.

I found my code would die with this error until I added this:

```
Traceback (most recent call last):
[...]
googleapiclient.errors.UnknownApiNameOrVersion: name: photoslibrary  version: v1
```

Searching around I found [this StackOverflow answer](https://stackoverflow.com/questions/66689941/google-photos-api-new-version) which fixed the problem.